### PR TITLE
Remove bootstrap from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@vue/eslint-config-standard": "^4.0.0",
     "axios": "^0.18.0",
-    "bootstrap": "^4.2.1",
     "dotenv": "^8.0.0",
     "element-ui": "^2.5.4",
     "nouislider": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,11 +1597,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
-bootstrap@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.2.1.tgz#8f8bdca024dbf0e8644da32e918c8a03a90a5757"
-  integrity sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Apparently the actual Bootstrap 4 node dependency is not being used (not loaded anywhere in the ui kit)

The files being used to style the components are in https://github.com/indiehd/web-ui/tree/master/src/assets/sass/indiehd

It appears that `Creative Tim` has simply copy/pasted the bootstrap src and modified it to style this kit ...

I'm actually not sure if i like this approach, but for the time being until we feel a requirement to include the bootstrap src, we can remove it here.